### PR TITLE
Ownverter 1.1.1 version selector

### DIFF
--- a/.github/workflows/publish_1.0.yml
+++ b/.github/workflows/publish_1.0.yml
@@ -139,19 +139,7 @@ jobs:
           rm -rf docs/spinV11
           rm -rf docs/spinV10
 
-      - name: Checkout OwnTech OWNVERTER V1.1 repo
-        uses: actions/checkout@v4
-        with:
-          repository: owntech-foundation/ownverter
-          ref: OWNVERTER_V1.1
-          path: docs/ownverterV11
-          sparse-checkout: |
-            docs/getting_started.md
-            docs/images/
-            docs/images/*
-          sparse-checkout-cone-mode: false
-          
-      - name: Checkout OwnTech OWNVERTER V1.0 repo
+      - name: Checkout OwnTech OWNVERTER V1_1_0 repo
         uses: actions/checkout@v4
         with:
           repository: owntech-foundation/ownverter
@@ -162,6 +150,19 @@ jobs:
             docs/images/
             docs/images/*
           sparse-checkout-cone-mode: false
+
+      - name: Checkout OwnTech OWNVERTER V1_1_1 repo
+        uses: actions/checkout@v4
+        with:
+          repository: owntech-foundation/ownverter
+          ref:  OWNVERTER_V1.1
+          path: docs/ownverterV11
+          sparse-checkout: |
+            docs/getting_started.md
+            docs/images/
+            docs/images/*
+          sparse-checkout-cone-mode: false
+
 
       - name: Remove unecessary ownverter folder
         run: |
@@ -175,6 +176,10 @@ jobs:
           mv docs/ownverterV10/docs/images/* docs/ownverter/1.0.0/images
           mv docs/ownverterV11/docs/images/* docs/ownverter/1.1.0/images
           rm -rf docs/ownverterV10
+          mkdir docs/ownverter/1.1.1
+          mkdir docs/ownverter/1.1.1/images/
+          mv docs/ownverterV11/docs/getting_started.md docs/ownverter/1.1.1/getting_started.md
+          mv docs/ownverterV11/docs/images/* docs/ownverter/1.1.1/images
           rm -rf docs/ownverterV11
 
       - name: Checkout OwnTech Control library repo

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 # VSCODE config
 .vscode/*
 site/*
-.venv/*
+*venv/*
+docs/*
 .secrets

--- a/docs/javascripts/version_selector.js
+++ b/docs/javascripts/version_selector.js
@@ -42,11 +42,15 @@ document$.subscribe(function() {
             versions = {
                 "1.1.0": {
                     buttonText: "1.1.0",
-                    aliasText: "Latest"
+                    aliasText: "Stable"
                 },
                 "1.0.0": {
                     buttonText: "1.0.0",
                     aliasText: "Stable"
+                },
+                "1.1.1": {
+                    buttonText: "1.1.1",
+                    aliasText: "Latest"
                 }
             };
         }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,8 +8,7 @@ INHERIT: mkdocs-common.yml
 
 
 nav:
-    - Home:
-        - index.md
+    - Home: index.md
     - Getting Started:
         - Environment Setup: core/docs/environment_setup.md
         - First Example: core/docs/first_example.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
             - CAN: powerAPI/classCanCommunication.md
             - Real Time Sync: powerAPI/classSyncCommunication.md
         - Safety API: powerAPI/classsafety.md
+        
     - Control Library:
         - Getting started: controlLibrary/docs/getting-started.md
         - Controller:

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -89,15 +89,20 @@
 {% endif %}
 
 
-{% if 'ownverter/' in page.file.src_path %}  
+{% if 'ownverter/' in page.file.src_path %}
 <div class="md-version" style="margin-left: 70%;">
-  <button id="versionButton" class="md-version__current" aria-label="Select version">1.1.0
+  <button id="versionButton" class="md-version__current" aria-label="Select version">1.1.1
     <span class="md-version__alias">Latest</span>
   </button>
-  <ul class="md-version__list" style="list-style-type: none; position: relative; top:-4 rem; z-index: 1000;"> 
+  <ul class="md-version__list" style="list-style-type: none; position: relative; top:-4 rem; z-index: 1000;">
+    <li class="md-version__item">
+      <a href="https://docs.owntech.org/1.0.0/ownverter/1.1.1/getting_started/" class="md-version__link">1.1.1
+        <span class="md-version__alias">Latest</span>
+      </a>
+    </li>
     <li class="md-version__item">
       <a href="https://docs.owntech.org/1.0.0/ownverter/1.1.0/getting_started/" class="md-version__link">1.1.0
-        <span class="md-version__alias">Latest</span>
+        <span class="md-version__alias">stable</span>
       </a>
     </li>
     <li class="md-version__item">

--- a/version-specific-yaml/mkdocs_1.0.yml
+++ b/version-specific-yaml/mkdocs_1.0.yml
@@ -2,8 +2,7 @@ INHERIT: mkdocs-common.yml
 
 
 nav:
-    - Home:
-        - index.md
+    - Home: index.md
     - Getting Started:
         - Environment Setup: core/docs/environment_setup.md
         - First Example: core/docs/first_example.md

--- a/version-specific-yaml/mkdocs_1.0.yml
+++ b/version-specific-yaml/mkdocs_1.0.yml
@@ -113,7 +113,7 @@ nav:
     - Hardware:
         - SPIN: spin/1.2.0/getting_started.md
         - TWIST: twist/1.4.1/getting_started.md
-        - OWNVERTER: ownverter/1.1.0/getting_started.md
+        - OWNVERTER: ownverter/1.1.1/getting_started.md
         
     - MATLAB:
         - Getting started: Matlab/docs/getting_started.md


### PR DESCRIPTION
**Description**

I have updated the ownverter documentation to modify the v1.1.1 images and solve a few typoes. 
I have updated the documentation center so that: 
- it supports ownverter version 1.1.1
- it solves an issue with the double Home that is visible on cell phone usage of the site. 

Changes were verified with the new act workflow that is now documented on the repository main.  